### PR TITLE
Fix mimedecode dropping events without source field

### DIFF
--- a/bin/MIMEdecode.py
+++ b/bin/MIMEdecode.py
@@ -145,7 +145,7 @@ class decodemimeCommand(StreamingCommand):
         for record in records:
             if field_in in record:
                 record[field_out] = main(record[field_in])
-                yield record
+            yield record
     
 if __name__ == "__main__":
     dispatch(decodemimeCommand, sys.argv, sys.stdin, sys.stdout, __name__)


### PR DESCRIPTION
### Motivation
- Fix a bug in `decodemimeCommand.stream` where events that did not contain the input field were dropped instead of being forwarded unchanged.

### Description
- Move `yield record` outside the `if field_in in record` branch so every input record is yielded while still assigning `record[field_out] = main(record[field_in])` only when the input field exists.

### Testing
- Ran `python -m py_compile bin/MIMEdecode.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b73a45460832d932c6a9119e2e84f)