### PR TITLE
Improve MIME decoding robustness and simplify header parsing

### DIFF
--- a/bin/MIMEdecode.py
+++ b/bin/MIMEdecode.py
@@ -37,43 +37,43 @@ def getmailheader(header_text, default="ascii"):
     """Decode header_text if needed.  
        Note: This function works by itself but if there are multiple strings that 
              need decoded you get encoding in the middle of the results"""
+    def _decode_headers(headers_to_decode):
+        decoded_headers = []
+        for text, charset in headers_to_decode:
+            try:
+                decoded_headers.append(six.text_type(text, charset or default, errors='replace'))
+            except LookupError:
+                # if the charset is unknown, force default
+                decoded_headers.append(six.text_type(text, default, errors='replace'))
+        return u"".join(decoded_headers)
+
     try:
-        headers=email.header.decode_header(header_text)
+        headers = email.header.decode_header(header_text)
     except email.errors.HeaderParseError:
-    # If the string doesn't decode correctly try stripping a few end characters
-        header_len=len(header_text)
-        if header_len>10:
+        # If the string doesn't decode correctly try stripping a few end characters
+        header_len = len(header_text)
+        for chars_to_trim in (3, 4, 5):
+            if header_len <= (chars_to_trim + 2):
+                continue
             try:
-                headers=email.header.decode_header(header_text[0:header_len-3]+'?=')
+                repaired_header = header_text[0:header_len - chars_to_trim] + '?='
+                headers = email.header.decode_header(repaired_header)
+                return _decode_headers(headers)
             except email.errors.HeaderParseError:
-                try:
-                    headers=email.header.decode_header(header_text[0:header_len-4]+'?=')
-                except email.errors.HeaderParseError:
-                    try:
-                        headers=email.header.decode_header(header_text[0:header_len-5]+'?=')
-                    except email.errors.HeaderParseError:
-                    # If all else fails return ***CORRUPTED***
-                        return "***CORRUPTED***"
-        for i, (text, charset) in enumerate(headers):
-            try:
-                headers[i]=six.text_type(text, charset or default, errors='replace')
-            except LookupError:
-            # if the charset is unknown, force default
-                headers[i]=six.text_type(text, default, errors='replace')
-        return u"".join(headers)
-    else:
-        for i, (text, charset) in enumerate(headers):
-            try:
-                headers[i]=six.text_type(text, charset or default, errors='replace')
-            except LookupError:
-            # if the charset is unknown, force default
-                headers[i]=six.text_type(text, default, errors='replace')
-        return u"".join(headers)
+                continue
+
+        # If all else fails return ***CORRUPTED***
+        return "***CORRUPTED***"
+
+    return _decode_headers(headers)
 
 def decode_subject( subject ):
     """Decode subject string if needed.  
        Note: This function splits each segment that might need decoded and calls 
              getmailheader for each part merging the results all together"""
+    if not subject:
+        return subject
+
     decoded = ''
     pointer = 0
     length = len(subject)
@@ -116,24 +116,23 @@ def main(message_subject):
     if message_subject is None:
         return None
 
-    MIMEEncode = str(message_subject)
+    mime_encode = str(message_subject)
  
     # only the MIMEEcode was provided, preform decoding where needed
-    if MIMEEncode.find("=?") == -1:
+    if mime_encode.find("=?") == -1:
         # If the field does not appear to contain encoded data return original field 
-        MIMEDecode = MIMEEncode
+        mime_decode = mime_encode
     else:
     # Else remove extra charaters not part of the encoding and decode the field 
 	# remove extra space after '?Q?' as it breaks decoding function later
-        MIMEEncode = re.sub(r'(\?[qQ]\?)\s*', r'\1', MIMEEncode)
+        mime_encode = re.sub(r'(\?[qQ]\?)\s*', r'\1', mime_encode)
 	# remove the rest as per else statement
-        MIMEDecode = MIMEEncode.replace('??','')
-        MIMEDecode = MIMEDecode.replace('? ','')
-        MIMEDecode = decode_subject(MIMEDecode)
+        mime_decode = re.sub(r'\?\?|\?\s', '', mime_encode)
+        mime_decode = decode_subject(mime_decode)
         #result[MIMEDecode] = getmailheader(result[MIMEEncode])
-    if MIMEDecode:
+    if mime_decode:
         # If successfully decoded then return results 
-        return MIMEDecode
+        return mime_decode
 
 # Splunk SDK skeleton
 @Configuration()


### PR DESCRIPTION
### Motivation
- Reduce duplicated charset-conversion logic and make header decoding easier to maintain.
- Improve resilience to malformed/partial MIME headers and avoid crashes on empty subjects.

### Description
- Introduced a shared helper `_decode_headers` inside `getmailheader` to centralize charset conversion and remove duplicated loops.
- Replaced nested repair attempts with a compact loop that trims (3/4/5) characters and returns on the first successful `email.header.decode_header` parse.
- Added an early return in `decode_subject` for empty inputs to skip unnecessary processing.
- Normalized variable names in `main` to `mime_encode`/`mime_decode` and consolidated malformed-separator cleanup with a single regex before decoding.

### Testing
- Ran `python3 -m py_compile bin/MIMEdecode.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b78eff714832db1f9a3c2e56c284e)